### PR TITLE
Overhauling code base

### DIFF
--- a/netbox_ipscanner.py
+++ b/netbox_ipscanner.py
@@ -1,104 +1,108 @@
-import pynetbox, urllib3, networkscan, socket, ipaddress
-from extras.scripts import Script
+from extras.scripts import Script, StringVar, BooleanVar, ObjectVar
+from extras.models import Tag
+from ipam.models import IPAddress, Prefix
+import nmap
 
-TOKEN='xxx'
-NETBOXURL='https://netbox.eample.com'
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning) #disable safety warnings
 
 class IpScan(Script):
-    #optional variables in UI here!
-    TagBasedScanning = BooleanVar(
-        label="Tag Based Scanning?",
+    # optional variables in UI here!
+    target_prefix = ObjectVar(
+        label='Target Prefix',
+        description='The CIDR prefix you would like to scan for hostnames',
+        model=Prefix,
+        null_option=True,
+        required=False,
+    )
+    create_new = BooleanVar(
+        label="Create New Objects",
+        default=True,
+        description="Whether to create new objects for non-existant NetBox items"
+    )
+    enabled_filter = BooleanVar(
+        label="Tag Based Scanning",
         default=False,
-        description="enable Tag Based Scanning, to scan only Subnets with specified Tag.",
+        description="Whether to filter the hosts by the provided Scan Tag",
     )
-    tag = StringVar(
-         max_length=20,
-         label="Scan Tag?",
-         default="scan",
-         description="specify the Tag to filter Subnets to be scanned",
-         required=True,
+    scan_recursive = BooleanVar(
+        label="Scan Recursively",
+        default=False,
+        description="This will scan a whole tagged network, and work against each address as if it were tagged",
     )
-
+    scan_tag = ObjectVar(
+        label="Tag Filter",
+        description="Select the Tag to filter Prefixes to be filtered by",
+        model=Tag,
+        null_option=True,
+        required=False,
+    )
 
     class Meta:
-        name = "IP Scanner"
+        name = "Subnet Scanner"
         description = "Scans available prefixes and updates ip addresses in IPAM Module"
 
- 
     def run(self, data, commit):
+        target_prefix = data['target_prefix']
+        enabled_filter = data['enabled_filter']
+        scan_recursive = data['scan_recursive']
+        create_new = data['create_new']
 
-        def reverse_lookup(ip):
-            '''
-            Mini function that does DNS reverse lookup with controlled failure
-            '''
-            try:
-                data = socket.gethostbyaddr(ip)
-            except Exception:
-                return '' #fails gracefully
-            if data[0] == '': #if there is no name
-                return ''
-            else:
-                return data[0]
+        if enabled_filter:
+            scan_tag = data['scan_tag']
 
-        nb = pynetbox.api(NETBOXURL, token=TOKEN)
-        nb.http_session.verify = False #disable certificate checking
+        def process_prefix(cidr_network):
+            # Grab CIDR prefix from provided CIDR range
+            prefix = cidr_network.mask_length
 
-        subnets = nb.ipam.prefixes.all() #extracts all prefixes, in format x.x.x.x/yy
+            # Instantiate an NMAP scan generator for quicker processing
+            nm = nmap.PortScannerYield()
 
-        for subnet in subnets:
-            if data['TagBasedScanning'] and data['tag'] not in str(subnet.tags): # Only scan subnets with the Tag
-                self.log_debug(f'checking {subnet}...Tag is {subnet.tags}')
-                self.log_warning(f"Scan of {subnet.prefix} NOT done (missing '{data['tag']}' tag)")
-                continue
-            if str(subnet.status) == 'Reserved': #Do not scan reserved subnets
-                self.log_warning(f"Scan of {subnet.prefix} NOT done (is Reserved)")
-                continue
-            self.log_debug(f'checking {subnet}...Tag is {subnet.tags}')
-            IPv4network = ipaddress.IPv4Network(subnet)
-            mask = '/'+str(IPv4network.prefixlen)
-            scan = networkscan.Networkscan(subnet)
-            scan.run()
-            self.log_info(f'Scan of {subnet} done.')
-	    
-            #Routine to mark as DEPRECATED each Netbox entry that does not respond to ping
-            for address in IPv4network.hosts(): #for each address of the prefix x.x.x.x/yy...
-		        #self.log_debug(f'checking {address}...')
-                netbox_address = nb.ipam.ip_addresses.get(address=address) #extract address info from Netbox
-                if netbox_address != None: #if the ip exists in netbox // if none exists, leave it to discover
-                    if str(netbox_address).rpartition('/')[0] in scan.list_of_hosts_found: #if he is in the list of "alive"
-                        pass #do nothing: It exists in NB and is in the pinged list: ok continue, you will see it later when you cycle the ip addresses that have responded whether to update something
-			            #self.log_success(f"The host {str(netbox_address).rpartition('/')[0]} exists in netbox and has been pinged")
-                    else: #if it exists in netbox but is NOT in the list, mark it as deprecated
-                        if str(netbox_address.status) == 'Deprecated' or str(netbox_address.status) == 'Reserved': #check the ip address to be Deprecated or Reserved
-                            pass # leave it as is
+            # Loop through the returned dict
+            # The provided '-sL' arguments narrow the scan down to just
+            # gathering the hostname data from each host
+            for host, response in nm.scan(hosts=str(cidr_network), arguments='-sL'):
+                # Store this data for handy use later (ew, that nesting)
+                hostname = response['scan'][host]['hostnames'][0]['name']
+
+                cidr = f'{host}/{prefix}'
+
+                try:
+                    # Looking for existing objects in NetBox
+                    this_address = IPAddress.objects.get(address=cidr)
+                    if enabled_filter and (this_address.tags.contains(scan_tag) or scan_recursive):
+                        if not hostname and this_address.status not in ['reserved', 'deprecated']:
+                            this_address.status = 'deprecated'
+                            if commit:
+                                self.log_info(
+                                    f'{cidr}: No response from existing address, deprecating')
+                                this_address.save()
+                        elif hostname and this_address.status == 'deprecated':
+                            this_address.status = 'active'
+                            if commit:
+                                self.log_info(
+                                    f'{cidr}: Response from deprecated host, reactivating')
+                                this_address.save()
+
+                except IPAddress.DoesNotExist:
+                    # Only act against hosts that return hostname data
+                    if hostname:
+                        if create_new:
+                            # Only creates a new object if one does not exist
+                            new_address = IPAddress(
+                                address=cidr,
+                                dns_name=hostname,
+                                description=f'Automatically pulled by {self.Meta.name}',
+                            )
+                            if commit:
+                                # Evaluates the Commit checkbox on form submission
+                                new_address.save()
+                                self.log_info(
+                                    f'{cidr}: Response from new address, adding')
                         else:
-                            self.log_warning(f"Host {str(netbox_address)} exists in netbox but not responding --> DEPRECATED")
-                            nb.ipam.ip_addresses.update([{'id':netbox_address.id, 'status':'deprecated'},])
-            ####
+                            self.log_info(
+                                f'{cidr}: Response from new address, skipping')
 
-            if scan.list_of_hosts_found == []:
-                self.log_warning(f'No host found in network {subnet}')
-            else:
-                self.log_success(f'IPs found: {scan.list_of_hosts_found}')
-            for address1 in scan.list_of_hosts_found: #for each ip in the ping list...
-                ip_mask=str(address1)+mask
-                current_in_netbox = nb.ipam.ip_addresses.get(address=ip_mask) #extract current data in Netbox related to ip
-                #self.log_debug(f'pinged ip: {address1} mask: {mask} --> {ip_mask} // extracted ip from netbox: {current_in_netbox}')
-                if current_in_netbox != None: #the pinged address is already present in the Netbox, mark it as Active and check the name if it has changed
-                    nb.ipam.ip_addresses.update([{'id':current_in_netbox.id, 'status':'active'},])
-                    name = reverse_lookup(address1) #name resolution from DNS
-                    if current_in_netbox.dns_name == name: #the names in Netbox and DNS match, do nothing
-                        pass
-                    else: #the names in Netbox and in DNS *DO NOT* match --> update Netbox with DNS name
-                        self.log_success(f'Name for {address1} updated to {name}')
-                        nb.ipam.ip_addresses.update([{'id':current_in_netbox.id, 'dns_name':name},])
-                else: #the pinged address is NOT present in Netbox, I have to add it
-                    name = reverse_lookup(address1) #name resolution from DNS
-                    res = nb.ipam.ip_addresses.create(address=ip_mask, status='active', dns_name=name)
-                    if res:
-                        self.log_success(f'Added {address1} - {name}')
-                    else:
-                        self.log_error(f'Adding {address1} - {name} FAILED')
-						
+        if target_prefix:
+            process_prefix(target_prefix)
+        else:
+            for prefix in Prefix.objects.filter(tags=scan_tag):
+                process_prefix(prefix.prefix)


### PR DESCRIPTION
# Changes
- Moved from networkscan to nmap
- Moved from pynetbox to direct object manipulation
- Added ability to filter by network
- Added ability to recursively scan whole tagged network, even if Addresses aren't tagged
- Added ability to toggle creation of newly-found objects
- Changed tag input from StringVar to ObjectVar

## Critical
### Moved from networkscan to nmap
The `networkscan` library is noticably faster than the `nmap` library, but it is not nearly as thorough. Hosts denying ICMP while still providing PTR content are ignored entirely.  
This brings the added benefit of using the `PortScannerYield` generator to keep everything in a single loop

### Moved from pynetbox to direct object manipulation
Custom NetBox scripts have functionality for manipulating local data in a much easier way than `pynetbox`; the latter should only ever be used when pulling data from another NetBox instance.

### Changed tag input from StringVar to ObjectVar
When referencing existing objects in NetBox, it is best to use an ObjectVar to ensure only existing objects are returned.


## QoL
### Added ability to filter by network
Added QoL for providing a range of functionality.

### Added ability to recursively scan whole tagged network, even if Addresses aren't tagged
Added QoL for providing a range of functionality.

### Added ability to toggle creation of newly-found objects
Added QoL for providing a range of functionality.